### PR TITLE
Fix: better error message to clarify private key format requirements

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	pubKey, err := utils.GetCompressedPublicKey()
 	if err != nil {
-		log.Fatal("Error loading .env file")
+		log.Fatal("Error getting public key: Please ensure your private key does not start with '0x'")
 	}
 	log.Printf("Compressed Public Key: %s", pubKey)
 


### PR DESCRIPTION
This PR improves the error message when public key generation fails due to incorrect private key format.

Changes:
- Updated the error message in main.go to specifically instruct users to check their private key format
- Added explicit mention that private keys should not start with "0x"
- Replaced generic error message with actionable guidance

This change helps users quickly identify and fix configuration issues without needing to debug the code.