### PR TITLE
fix: centralize environment loading to avoid duplicate .env processing

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,14 +31,24 @@ func Worker(ctx context.Context, wg *sync.WaitGroup, id int) {
 }
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Fatal("Error loading .env file")
-	}
+	workDir, _ := os.Getwd()
+	fmt.Printf("Current working directory: %s\n", workDir)
 
+	err := godotenv.Load("./.env")
+	if err != nil {
+		altErr := godotenv.Load()
+		if altErr != nil {
+			log.Println("Warning: .env file not found, will use default values if needed")
+		} else {
+			log.Println("Environment loaded from default location")
+		}
+	} else {
+		log.Println("Environment loaded from ./.env")
+	}
+	
 	pubKey, err := utils.GetCompressedPublicKey()
 	if err != nil {
-		log.Fatal("Error loading .env file")
+		log.Fatalf("Error getting compressed public key: %v", err)
 	}
 	log.Printf("Compressed Public Key: %s", pubKey)
 

--- a/utils/get_env.go
+++ b/utils/get_env.go
@@ -1,17 +1,10 @@
 package utils
 
 import (
-	"log"
 	"os"
-
-	"github.com/joho/godotenv"
 )
 
 func GetEnv(key, defaultValue string) string {
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("Warning: .env file not loaded in processor")
-	}
 	if value, exists := os.LookupEnv(key); exists {
 		return value
 	}


### PR DESCRIPTION
This commit fixes the environment loading mechanism by:
- Removing duplicate .env loading in utils/get_env.go
- Centralizing all environment loading in main.go
- Adding better error handling with more descriptive messages
- Making .env loading non-fatal to support fallback to default values
- Improving debugging by displaying the working directory

The previous implementation attempted to load the .env file in multiple places, leading to confusing error messages and potential inconsistencies. This change makes the environment loading process more robust and easier to debug when issues occur.